### PR TITLE
Suppress template debug deprecation warning

### DIFF
--- a/papusa/settings/base.py
+++ b/papusa/settings/base.py
@@ -162,6 +162,7 @@ TEMPLATES = [
                 'django.template.context_processors.static',
                 'django.contrib.messages.context_processors.messages',
             ],
+            'debug': DEBUG,
         },
     },
 ]


### PR DESCRIPTION
When running a manage.py command, a django warning would apear about a
future deprecation of the way DEBUG is set for templates.
See here for solution and problem.
https://stackoverflow.com/questions/32445953/django-app-works-fine-but-getting-a-template-warning-message

Now this message doesn't apear.